### PR TITLE
Upgrade to zeroize v0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ sha-1 = { version = "0.8.1", default-features = false }
 hex = "0.3.2"
 reqwest = "0.9.17"
 rpassword = "3.0.2"
-zeroize = "0.8.0"
+zeroize = "0.9.1"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"


### PR DESCRIPTION
I'm attempting to phase out and eventually yank `zeroize` v0.8 because its custom derive support contained an API which implicitly zeroized on drop, and I'm trying to move to an explicit one.

You don't appear to be using the custom derive support so you won't be affected, however you will be affected by the yank, so this PR bumps the version.