### PR TITLE
Use padded responses from password API

### DIFF
--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -23,7 +23,7 @@
 /// All the different errors for checkpwn;
 /// Errors that are meant to be internal or or unreachable print this.
 pub const USAGE_ERROR: &str = "Usage: checkpwn (acc/pass) (username/email/account_list.ls)";
-pub const STATUSCODE_ERROR: &str = "Unrecognized status code recevied";
+pub const STATUSCODE_ERROR: &str = "Unrecognized status code received";
 pub const PASSWORD_ERROR: &str = "Error retrieving password from stdin";
 pub const READ_FILE_ERROR: &str = "Error reading local file";
 pub const NETWORK_ERROR: &str = "Failed to send request to HIBP";
@@ -31,7 +31,7 @@ pub const DECODING_ERROR: &str = "Failed to decode response from HIBP";
 pub const API_ARG_ERROR: &str =
     "SHOULD_BE_UNREACHABLE: Invalid argument in API route construction detected";
 pub const BAD_RESPONSE_ERROR: &str =
-    "Recevied a bad response from HIBP - make sure the account is valid";
+    "Received a bad response from HIBP - make sure the account is valid";
 pub const BUFREADER_ERROR: &str = "Failed to read file in to BufReader";
 pub const READLINE_ERROR: &str = "Failed to read line from file";
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -78,7 +78,7 @@ fn format_req(api_route: &CheckableChoices, search_term: &str) -> String {
     request
 }
 
-/// Take the user-supplied command-line arugments and make a URL for the HIBP API.
+/// Take the user-supplied command-line arguments and make a URL for the HIBP API.
 /// If the `pass` argument has been selected, `input_data` needs to be the hashed password.
 pub fn arg_to_api_route(arg: &CheckableChoices, input_data: &str) -> String {
     match arg {
@@ -91,14 +91,21 @@ pub fn arg_to_api_route(arg: &CheckableChoices, input_data: &str) -> String {
     }
 }
 
-/// Find matching key in recevied set of keys.
+/// Find matching key in received set of keys.
 pub fn search_in_range(password_range_response: &str, hashed_key: &str) -> bool {
     for line in password_range_response.lines() {
-        // Each response is truncated to only be the hash, no whitespaces, etc.
+        let pair: Vec<_> = line.split(':').collect();
+        // Padded entries always have an occurrence of 0 and should be
+        // discarded.
+        if *pair.get(1).unwrap() == "0" {
+            continue;
+        }
+
+        // Each response is truncated to only be the hash, no whitespace, etc.
         // All hashes here have a length of 35, so the useless gets dropped by
         // slicing. Don't include first five characters of own password, as
         // this also is how the HIBP API returns passwords.
-        if line[..35] == hashed_key[5..] {
+        if *pair.get(0).unwrap() == &hashed_key[5..] {
             return true;
         }
     }
@@ -106,7 +113,7 @@ pub fn search_in_range(password_range_response: &str, hashed_key: &str) -> bool 
     false
 }
 
-/// Make a breach report based on StatusCode and print result to temrinal.
+/// Make a breach report based on StatusCode and print result to terminal.
 pub fn breach_report(status_code: StatusCode, searchterm: &str, is_password: bool) -> ((), bool) {
     // Do not display password in terminal
     let request_key = if is_password { "********" } else { searchterm };
@@ -221,7 +228,7 @@ fn test_breach_invalid_status() {
 }
 
 #[test]
-fn test_search_succes_and_failure() {
+fn test_search_success_and_failure() {
     // https://api.pwnedpasswords.com/range/B1B37
 
     let contains_pass = String::from(

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn acc_check(data_search: &str) {
                 continue;
             }
             api::acc_breach_request(&line);
-            // Only one request every 1500 miliseconds from any given IP
+            // Only one request every 1500 milliseconds from any given IP
             thread::sleep(time::Duration::from_millis(1600));
         }
     } else {
@@ -66,6 +66,10 @@ fn pass_check(data_search: &api::PassArg) {
     headers.insert(
         header::USER_AGENT,
         header::HeaderValue::from_static(api::CHECKPWN_USER_AGENT),
+    );
+    headers.insert(
+        "Add-Padding",
+        header::HeaderValue::from_str("true").unwrap(),
     );
 
     let client = Client::builder().default_headers(headers).build().unwrap();
@@ -117,7 +121,7 @@ fn main() {
     for argument in argvs.iter_mut() {
         argument.zeroize();
     }
-    // Only one request every 1500 miliseconds from any given IP
+    // Only one request every 1500 milliseconds from any given IP
     thread::sleep(time::Duration::from_millis(1600));
 }
 


### PR DESCRIPTION
To improve the privacy of the HIBP password API, [padded responses](https://www.troyhunt.com/enhancing-pwned-passwords-privacy-with-padding/) have been added. This PR changes checkpwn to utilize the padded responses whenever the password API is queried.