### PR TITLE
Register API Key Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Cargo.lock
 **/*.rs.bk
 
 list.ls
+
+# Good ol' Mac.
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ reqwest = { version = "0.10.0", features = ["blocking"] }
 rpassword = "4.0.3"
 zeroize = "1.1.0"
 dirs = "2.0.2"
+serde = { version = "1.0.106" , features = ["derive"] }
+serde_yaml = "0.8.11"
 
 [dev-dependencies]
 assert_cmd = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hex = "0.4.0"
 reqwest = { version = "0.10.0", features = ["blocking"] }
 rpassword = "4.0.3"
 zeroize = "1.1.0"
+dirs = "2.0.2"
 
 [dev-dependencies]
 assert_cmd = "0.12.0"

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -22,7 +22,7 @@
 
 /// All the different errors for checkpwn;
 /// Errors that are meant to be internal or or unreachable print this.
-pub const USAGE_ERROR: &str = "Usage: checkpwn (acc/pass) (username/email/account_list.ls)";
+pub const USAGE_ERROR: &str = "Usage: checkpwn { pass | acc (<username> | <email> | <filename>.ls) | register <apikey> }";
 pub const STATUSCODE_ERROR: &str = "Unrecognized status code recevied";
 pub const PASSWORD_ERROR: &str = "Error retrieving password from stdin";
 pub const READ_FILE_ERROR: &str = "Error reading local file";

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -33,7 +33,6 @@ use self::sha1::{Digest, Sha1};
 use reqwest::StatusCode;
 use zeroize::Zeroize;
 
-use std::env;
 use std::fs::File;
 use std::io::{BufReader, Error};
 use std::panic;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -33,6 +33,7 @@ use self::sha1::{Digest, Sha1};
 use reqwest::StatusCode;
 use zeroize::Zeroize;
 
+use std::env;
 use std::fs::File;
 use std::io::{BufReader, Error};
 use std::panic;
@@ -106,7 +107,7 @@ pub fn search_in_range(password_range_response: &str, hashed_key: &str) -> bool 
     false
 }
 
-/// Make a breach report based on StatusCode and print result to temrinal.
+/// Make a breach report based on StatusCode and print result to terminal.
 pub fn breach_report(status_code: StatusCode, searchterm: &str, is_password: bool) -> ((), bool) {
     // Do not display password in terminal
     let request_key = if is_password { "********" } else { searchterm };

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,7 @@ impl Config {
 
                 if !app_config_dir.exists() {
                     match fs::create_dir_all(&app_config_dir) {
-                        Ok(path) => println!("Successfully created checkpwn configuration directories at {:?}", path),
+                        Ok(()) => println!("Successfully created checkpwn configuration directories at {:?}", &app_config_dir),
                         Err(e) => {
                             panic!("Error creating checkpwn configuration directories: {:?}", e)
                         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,11 +4,7 @@ extern crate serde_yaml;
 
 use self::dirs::config_dir;
 use self::serde::{Deserialize, Serialize};
-use std::{
-    fs, io,
-    io::Write,
-    path::{PathBuf},
-};
+use std::{fs, io, io::Write, path::PathBuf};
 
 const CHECKPWN_CONFIG_FILE_NAME: &str = "checkpwn.yml";
 const CHECKPWN_CONFIG_DIR: &str = "checkpwn";
@@ -30,7 +26,7 @@ impl Config {
         }
     }
 
-    fn get_config_path(&self) -> Option<ConfigPaths> {
+    pub fn get_config_path(&self) -> Option<ConfigPaths> {
         match config_dir() {
             Some(mut dir) => {
                 dir.push(CHECKPWN_CONFIG_DIR);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,78 @@
+use std::{
+    fs,
+    path::{Path, PathBuf}
+};
+
+// There might be a better approach here to handling configuration
+// directories across platform. The crate `directories` looks like a nice
+// option, but I noticed it had some `panics!()` within the code base.
+const CHECKPWN_CONFIG_FILE_NAME: &str = "checkpwn.yml";
+const CHECKPWN_CONFIG_DIR: &str = "checkpwn";
+
+pub struct Config {
+    pub api_key: String
+}
+
+#[derive(Debug)]
+pub struct ConfigPaths {
+    pub config_file_path: PathBuf,
+}
+
+impl Config {
+    pub fn new() -> Config {
+        Config {
+            api_key: "".to_string()
+        }
+    }
+
+    pub fn get_or_build_path(&self) -> Result<ConfigPaths, ()> {
+        // referenced from https://github.com/Rigellute/spotify-tui/blob/master/src/config.rs
+        // I found it difficult to use the `directories` crate -- particularly converting the
+        // `ProjectDirs` type to a `Path` type or a string
+        match dirs::config_dir() {
+            Some(config_dir) => {
+                let path = Path::new(&config_dir);
+                let app_config_dir = path.join(CHECKPWN_CONFIG_DIR);
+
+                if !app_config_dir.exists() {
+                    match fs::create_dir_all(&app_config_dir) {
+                        Ok(path) => println!("Successfully created checkpwn configuration directories at {:?}", path),
+                        Err(e) => {
+                            panic!("Error creating checkpwn configuration directories: {:?}", e)
+                        }
+                    }
+                }
+                let config_file_path = &app_config_dir.join(CHECKPWN_CONFIG_FILE_NAME);
+
+                let paths = ConfigPaths {
+                    config_file_path: config_file_path.to_path_buf(),
+                };
+
+                Ok(paths)
+            }
+            // is there a better way to handle this failure?
+            None => panic!("Could not find path for configuration file."),
+        }
+    }
+
+    pub fn load_config(&mut self) {
+        let path = match self.get_or_build_path() {
+            Ok(p) => p,
+            Err(e) => { panic!("Error retrieving configuration path: {:?}", e)}
+        };
+
+
+
+
+        if path.config_file_path.exists() {
+            let config_string = match fs::read_to_string(&path.config_file_path.to_str().unwrap()) {
+                Ok(p) => p,
+                Err(e) => { panic!("Error parsing path of configuration file to string: {:?}", e)}
+            };
+
+            //TODO: handle the `std::result::Result` returned from `serde_yaml::from_str`
+            //let config_yml: Config = serde_yaml::from_str(&config_string);
+        }
+
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use assert_cmd::prelude::*;
 use reqwest::blocking::Client;
 use reqwest::header;
 use reqwest::StatusCode;
-use std::io::BufRead;
+use std::io::{BufRead};
 use std::panic;
 #[cfg(test)]
 use std::process::Command;
@@ -95,9 +95,9 @@ fn pass_check(data_search: &api::PassArg) {
 
 fn main() {
     // Set custom usage panic message
-    //set_checkpwn_panic!(api::errors::USAGE_ERROR);
-    // assert!(env::args().len() >= 1);
-    // assert!(env::args().len() < 4);
+    set_checkpwn_panic!(api::errors::USAGE_ERROR);
+    assert!(env::args().len() >= 2);
+    assert!(env::args().len() < 4);
 
     let mut argvs: Vec<String> = env::args().collect();
 
@@ -114,18 +114,15 @@ fn main() {
             };
             pass_check(&password);
         }
-        "config" => {
-            let mut configuration = config::Config::new();
-            configuration.load_config();
-
-            println!("{:?}", configuration);
-        }
         "register" => {
             assert!(argvs.len() == 3);
             let configuration = config::Config::new();
-            configuration.save_config(&argvs[2]).unwrap();
+            match configuration.save_config(&argvs[2]) {
+                Ok(()) => println!("Successfully saved client configuration."),
+                Err(e) => panic!("Encounter error saving client configuration: {}", e)
+            }
         }
-        _ => panic!(),
+        _ => panic!()
     };
     // Zero out the collected arguments, in case the user accidentally inputs sensitive info
     for argument in argvs.iter_mut() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+mod config;
+
 #[cfg(test)]
 extern crate assert_cmd;
 extern crate reqwest;
@@ -110,6 +112,13 @@ fn main() {
                 password: rpassword::prompt_password_stdout("Password: ").unwrap(),
             };
             pass_check(&password);
+        }
+        "register" => {
+            let configuration = config::Config::new();
+            match configuration.get_or_build_path() {
+                Ok(path) => println!("Configuration paths found or created successfully: {:?}", path),
+                Err(e) => panic!(format!("Encountered error! Details: {:?}", e))
+            }
         }
         _ => panic!(),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,15 +19,14 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-
 mod config;
 
 #[cfg(test)]
 extern crate assert_cmd;
 extern crate reqwest;
 extern crate rpassword;
-extern crate zeroize;
 extern crate serde;
+extern crate zeroize;
 
 #[macro_use]
 pub mod api;
@@ -96,9 +95,9 @@ fn pass_check(data_search: &api::PassArg) {
 
 fn main() {
     // Set custom usage panic message
-    set_checkpwn_panic!(api::errors::USAGE_ERROR);
-    assert!(env::args().len() >= 2);
-    assert!(env::args().len() < 4);
+    //set_checkpwn_panic!(api::errors::USAGE_ERROR);
+    // assert!(env::args().len() >= 1);
+    // assert!(env::args().len() < 4);
 
     let mut argvs: Vec<String> = env::args().collect();
 
@@ -115,14 +114,16 @@ fn main() {
             };
             pass_check(&password);
         }
+        "config" => {
+            let mut configuration = config::Config::new();
+            configuration.load_config();
+
+            println!("{:?}", configuration);
+        }
         "register" => {
             assert!(argvs.len() == 3);
-            let configuration = config::Config::new(String::from(&argvs[2]));
-            match configuration.get_or_build_path() {
-                Ok(path) => println!("Configuration paths found or created successfully: {:?}", path),
-                Err(e) => panic!(format!("Encountered error! Details: {:?}", e))
-            }
-            configuration.save_config().unwrap();
+            let configuration = config::Config::new();
+            configuration.save_config(&argvs[2]).unwrap();
         }
         _ => panic!(),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ extern crate assert_cmd;
 extern crate reqwest;
 extern crate rpassword;
 extern crate zeroize;
+extern crate serde;
+
 #[macro_use]
 pub mod api;
 
@@ -114,11 +116,13 @@ fn main() {
             pass_check(&password);
         }
         "register" => {
-            let configuration = config::Config::new();
+            assert!(argvs.len() == 3);
+            let configuration = config::Config::new(String::from(&argvs[2]));
             match configuration.get_or_build_path() {
                 Ok(path) => println!("Configuration paths found or created successfully: {:?}", path),
                 Err(e) => panic!(format!("Encountered error! Details: {:?}", e))
             }
+            configuration.save_config().unwrap();
         }
         _ => panic!(),
     };


### PR DESCRIPTION
Fixes #13 
The HIBP API now requires an API key to use.

This PR provides functionality to `checkpwn` in `config.rs`:
- implements a `Config` struct to serialize and de-serialize configurations
- saving the API key to a configuration file with `save_config()` 
- reading and serializing the API key into a `Config` struct with `load_config()`