### PR TITLE
Wrapped Error type in Box

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -44,23 +44,27 @@ impl Config {
             .get_config_path()
             .expect("Failed to determine configuration file path.");
         path.config_file_path.pop(); //remove the filename so we don't accidentally create it as a directory
-        fs::create_dir_all(&path.config_file_path).unwrap();
+        fs::create_dir_all(&path.config_file_path)?;
         Ok(())
     }
 
     #[cfg(debug_assertions)]
-    pub fn load_config(&mut self) {
+    pub fn load_config(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         // If in CI, the key is in env. Local tests use the config file.
         match std::env::var("API_KEY") {
-            Ok(api_key) => self.api_key = api_key,
+            Ok(api_key) => {
+                self.api_key = api_key;
+                Ok(())
+            },
             Err(std::env::VarError::NotPresent) => {
                 let path = self
                     .get_config_path()
                     .expect("Failed to determine configuration file path.");
-                let config_string = fs::read_to_string(&path.config_file_path).unwrap();
-                let config_yml: Config = serde_yaml::from_str(&config_string).unwrap();
+                let config_string = fs::read_to_string(&path.config_file_path)?;
+                let config_yml: Config = serde_yaml::from_str(&config_string)?;
 
                 self.api_key = config_yml.api_key;
+                Ok(())
             }
             _ => panic!("CI API KEY WAS NOT UTF8"),
         }
@@ -71,8 +75,8 @@ impl Config {
         let path = self
             .get_config_path()
             .expect("Failed to determine configuration file path.");
-        let config_string = fs::read_to_string(&path.config_file_path).unwrap();
-        let config_yml: Config = serde_yaml::from_str(&config_string).unwrap();
+        let config_string = fs::read_to_string(&path.config_file_path)?;
+        let config_yml: Config = serde_yaml::from_str(&config_string)?;
 
         self.api_key = config_yml.api_key;
     }
@@ -82,14 +86,14 @@ impl Config {
             .get_config_path()
             .expect("Failed to determine configuration file path.");
 
-        self.build_path().unwrap();
+        self.build_path()?;
         let new_config = Config {
             api_key: api_key.to_string(),
         };
 
-        let config_to_write = serde_yaml::to_vec(&new_config).unwrap();
-        let mut config_file = fs::File::create(&path.config_file_path).unwrap();
-        config_file.write_all(&config_to_write).unwrap();
+        let config_to_write = serde_yaml::to_vec(&new_config)?;
+        let mut config_file = fs::File::create(&path.config_file_path)?;
+        config_file.write_all(&config_to_write)?;
 
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ extern crate serde_yaml;
 
 use self::dirs::config_dir;
 use self::serde::{Deserialize, Serialize};
-use std::{fs, io, io::Write, path::PathBuf};
+use std::{fs, io::Write, path::PathBuf};
 
 const CHECKPWN_CONFIG_FILE_NAME: &str = "checkpwn.yml";
 const CHECKPWN_CONFIG_DIR: &str = "checkpwn";
@@ -39,7 +39,7 @@ impl Config {
         }
     }
 
-    fn build_path(&self) -> Result<(), io::Error> {
+    fn build_path(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut path = self
             .get_config_path()
             .expect("Failed to determine configuration file path.");
@@ -77,7 +77,7 @@ impl Config {
         self.api_key = config_yml.api_key;
     }
 
-    pub fn save_config(&self, api_key: &String) -> Result<(), io::Error> {
+    pub fn save_config(&self, api_key: &String) -> Result<(), Box<dyn std::error::Error>> {
         let path: ConfigPaths = self
             .get_config_path()
             .expect("Failed to determine configuration file path.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
     for argument in argvs.iter_mut() {
         argument.zeroize();
     }
-    // Only one request every 1500 milliseconds from any given IP
+    // Only one request every 1600 milliseconds from any given IP
     thread::sleep(time::Duration::from_millis(1600));
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ use zeroize::Zeroize;
 fn acc_check(data_search: &str) {
     set_checkpwn_panic!(api::errors::MISSING_API_KEY);
     let mut config = config::Config::new();
-    config.load_config();
+    config.load_config().unwrap();
 
     // Check if user wants to check a local list
     if data_search.ends_with(".ls") {
@@ -60,7 +60,7 @@ fn acc_check(data_search: &str) {
                 continue;
             }
             api::acc_breach_request(&line, &config.api_key);
-            // Only one request every 1500 milliseconds from any given IP
+            // HIBP limits requests to one per 1500 milliseconds. We're allowing for 1600 below as a buffer.
             thread::sleep(time::Duration::from_millis(1600));
         }
     } else {


### PR DESCRIPTION
This PR makes a simple change the function signatures I implemented a few weeks ago. Instead of passing `io::Error` in the Result type -- I should be wrapping the Error trait in a Box to better handle all possibilities.